### PR TITLE
remove keywords terms from logic of whether to process a given package

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function collectBrowser(root) {
             rootPkg.children.forEach(processPackage);
 
             function processPackage(c) {
-                var browser = overrides[c.package.name] || c.package.browserPackage || (c.package.keywords && ~c.package.keywords.indexOf("browser"));
+                var browser = overrides[c.package.name] || c.package.browserPackage;
                 if (!browser) return;
                 var pkg = typeof browser === 'object' ? extendedCleanedMinusBrowser(c.package, browser) : c.package;
                 var pkgroot = c.path;


### PR DESCRIPTION
Resolves #5 

Of course this assumes that I haven't missed something about why those keywords are being looked at in the first place.
